### PR TITLE
feat: add touch-friendly two-finger pinch zoom and single-finger pan

### DIFF
--- a/src/controls.ts
+++ b/src/controls.ts
@@ -2,6 +2,10 @@ let dragStart: Point | null = null;
 let lastPoint: Point | null = null;
 let zoomBoxStart: Point | null = null;
 
+// Touch state
+let touchLastPoint: Point | null = null;
+let pinchState: { startDist: number; startCenter: Point; currentScale: number } | null = null;
+
 export function setupPlotListeners(canvas: HTMLCanvasElement, cbs: PlotCallbacks) {
     canvas.addEventListener("mousedown", e => {
         if (e.button === 2) {
@@ -79,6 +83,78 @@ export function setupPlotListeners(canvas: HTMLCanvasElement, cbs: PlotCallbacks
         const zoomPercent = 1.05 ** zoomFactor
         cbs.onZoom(zoomPercent, { x: e.offsetX, y: e.offsetY });
     });
+
+    // Touch support
+    canvas.addEventListener("touchstart", e => {
+        e.preventDefault();
+        if (e.touches.length === 1) {
+            // Single finger - prepare for pan
+            touchLastPoint = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+            pinchState = null;
+        } else if (e.touches.length === 2) {
+            // Two fingers - prepare for pinch zoom
+            const dist = getTouchDistance(e.touches[0], e.touches[1]);
+            const center = getTouchCanvasPoint(e.touches[0], e.touches[1], canvas);
+            pinchState = { startDist: dist, startCenter: center, currentScale: 1 };
+            touchLastPoint = null;
+        }
+    }, { passive: false });
+
+    canvas.addEventListener("touchmove", e => {
+        e.preventDefault();
+        if (e.touches.length === 1 && touchLastPoint !== null && pinchState === null) {
+            // Single finger pan - update position without re-rendering
+            const touch = e.touches[0];
+            cbs.onDragUpdate(
+                touch.clientX - touchLastPoint.x,
+                touch.clientY - touchLastPoint.y
+            );
+            touchLastPoint = { x: touch.clientX, y: touch.clientY };
+        } else if (e.touches.length === 2 && pinchState !== null) {
+            // Two finger pinch - update CSS transform for visual feedback only (no re-render)
+            const dist = getTouchDistance(e.touches[0], e.touches[1]);
+            const scale = dist / pinchState.startDist;
+            pinchState = { ...pinchState, currentScale: scale };
+            if (cbs.onTouchZoomUpdate) {
+                cbs.onTouchZoomUpdate(scale, pinchState.startCenter);
+            }
+        }
+    }, { passive: false });
+
+    canvas.addEventListener("touchend", e => {
+        e.preventDefault();
+        if (e.touches.length === 0) {
+            if (pinchState !== null) {
+                // Pinch complete - commit zoom with a single re-render
+                cbs.onZoom(pinchState.currentScale, pinchState.startCenter);
+                pinchState = null;
+            } else {
+                cbs.onDragComplete();
+            }
+            touchLastPoint = null;
+        } else if (e.touches.length === 1) {
+            // Transitioned from pinch back to single finger - commit zoom, resume pan
+            if (pinchState !== null) {
+                cbs.onZoom(pinchState.currentScale, pinchState.startCenter);
+                pinchState = null;
+            }
+            touchLastPoint = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+        }
+    }, { passive: false });
+}
+
+function getTouchDistance(t1: Touch, t2: Touch): number {
+    const dx = t1.clientX - t2.clientX;
+    const dy = t1.clientY - t2.clientY;
+    return Math.sqrt(dx * dx + dy * dy);
+}
+
+function getTouchCanvasPoint(t1: Touch, t2: Touch, canvas: HTMLCanvasElement): Point {
+    const rect = canvas.getBoundingClientRect();
+    return {
+        x: (t1.clientX + t2.clientX) / 2 - rect.left,
+        y: (t1.clientY + t2.clientY) / 2 - rect.top,
+    };
 }
 
 interface Point {
@@ -90,6 +166,7 @@ export interface PlotCallbacks {
     onDragUpdate(moveX: number, moveY: number): void;
     onDragComplete(): void;
     onZoom(zoomAmount: number, zoomCenter: Point): void;
+    onTouchZoomUpdate?(scale: number, center: Point): void;
     onMouseMove?(offsetX: number, offsetY: number, clientX: number, clientY: number): void;
     onMouseLeave?(): void;
     onMouseEnter?(): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,16 @@ function updateBoundsInputs() {
     onDragComplete() {
         updateUrl(plotBounds, plotOptions);
     },
+    onTouchZoomUpdate(scale, center) {
+        // Apply CSS scale transform for instant visual feedback during pinch (no re-render)
+        mainThCanvas.style.transformOrigin = `${center.x}px ${center.y}px`;
+        mainThCanvas.style.transform = `scale(${scale})`;
+    },
     onZoom(diff, center) {
+        // Reset any CSS transform applied during touch pinch before re-rendering
+        mainThCanvas.style.transform = "";
+        mainThCanvas.style.transformOrigin = "";
+
         // targetZoom *= diff;
         const oldRealRange = plotBounds.realRange;
         const oldImagRange = plotBounds.imagRange;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -3,8 +3,9 @@ body {
     margin: 0;
 }
 
-#plot {
+#plot, #worker-plot {
     box-sizing: border-box;
+    touch-action: none;
 }
 
 #plot-bounds {


### PR DESCRIPTION
- Single finger drag maps to pan (uses existing onDragUpdate/onDragComplete)
- Two-finger pinch applies a CSS scale transform on the canvas for instant
  visual feedback during the gesture with no Mandelbrot re-render
- Re-render is triggered once when the pinch ends via onZoom, keeping
  performance balanced between responsiveness and rendering cost
- Handles transition from pinch back to single-finger pan gracefully
- Adds touch-action: none to canvas elements to prevent browser scroll
  interference during touch gestures

https://claude.ai/code/session_01FrRkGfUmEwPUMd445ByJwQ